### PR TITLE
Keep track of available tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,6 @@ MINT_PRIVATE_KEY=supersecretprivatekey
 MINT_SERVER_HOST=127.0.0.1
 MINT_SERVER_PORT=3338
 
+LIGHTNING=TRUE
 LNBITS_ENDPOINT=https://legend.lnbits.com
 LNBITS_KEY=yourkeyasdasdasd

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Big thanks to [phyro](https://github.com/phyro) for their work and further discu
 
 ## Install
 ### Prerequisites
+These steps help you install Python via pyenv and Poetry. If you already have Poetry running on your computer, you can skip this step and jump right to [Install Cashu](#install-cashu).
 ```bash
 sudo apt install -y build-essential pkg-config libffi-dev libpq-dev zlib1g-dev libssl-dev python3-dev
 # on mac: brew install postgres
@@ -46,80 +47,7 @@ vim .env
 
 To use the wallet with the [public test mint](#test-instance), you need to change the appropriate entries in the `.env` file. 
 
-## Run a mint yourself
-This runs the mint on your local computer. Skip this step if you want to use the [public test mint](#test-instance) instead.
-```bash
-poetry run mint
-```
-
-## Use wallet
-
-#### Request a mint
-
-This command will return a Lightning invoice and a payment hash. You have to pay the invoice before you can receive the tokens. Note: Minting tokens involves two steps: requesting a mint, and actually minting tokens (see below).
-
-```bash
-poetry run cashu mint 420
-```
-Returns:
-```bash
-Balance: 0
-{
-    'pr': 'lnbc4200n1p3jp5clsp5vcfkyqtnkcx9287auhesqwj40che77pd4ymaltc3ruazh3vcgs3qpp5qzwkavpd4pmfkdmq9trdnrk2lswkt0fypqg55h2sucx6yq9ushzsdq4vdshx6r4ypjx2ur0wd5hgxqyjw5qcqpjrzjq0qly7quwdwq2wr52et5gl65dagdgqdwgn9an58mhejnsvmmu996xzetgvqqwzcqqqqqqqqqqqqqqqqq9q9qyysgqfjwnl4za4naf7l2wwcck2gk6y9mvjt5dz9gptfkpl0j50ygkdkuxyjcy3zgd2tk4995yw8gx39cx2qwm9dgwc0t9t6hrgvjzauykqrqpgw0xx3', 
-    'hash': '009d6eb02da8769b37602ac6d98ecafc1d65bd2408114a5d50e60da200bc85c5'
-}
-```
-
-#### Mint tokens
-After paying the invoice, copy the `hash` value from above and add it to the command
-```bash
-poetry run cashu mint 420 --hash=009d6eb02da8769b37602ac6d98ecafc1d65bd2408114a5d50e60da200bc85c5
-```
-You should see your balance update accordingly:
-```bash
-Balance: 0
-Balance: 420
-```
-
-#### Check balance
-```bash
-poetry run cashu balance
-```
-
-#### Send tokens
-To send tokens to another user, enter
-```bash
-poetry run cashu send 69
-```
-You should see the encoded token. Copy the token and send it to another user such as via email or a messenger. The token looks like this:
-```bash
-W3siYW1vdW50IjogMSwgIkMiOiB7IngiOiAzMzg0Mzg0NDYzNzAwMTY1NDA2MTQxMDY3Mzg1MDg5MjA2MTU2NjQxMjM4Nzg5MDE4NzAzODg0NjAwNDUzNTAwNzY3...
-```
-
-#### Receive tokens
-To receive tokens, another user enters:
-```bash
-poetry run cashu receive W3siYW1vdW50IjogMSwgIkMiOi...
-```
-You should see the balance increase:
-```bash
-wallet balance: 0
-wallet balance: 69
-```
-
-#### Burn tokens
-The sending user needs to burn (invalidate) their tokens from above, otherwise they will try to double spend them (which won't work because the server keeps a list of all spent tokens):
-```bash
-poetry run cashu burn W3siYW1vdW50IjogMSwgIkMiOi...
-```
-Returns:
-```bash
-wallet balance: 420
-wallet balance: 351
-```
-
-
-## Test instance
+#### Test instance
 *Warning: this instance is just for demonstration only. Currently, only Lightning deposits work but not withdrawals. The server could vanish at any moment so consider any Satoshis you deposit a donation. I will add Lightning withdrawals soon so unless someone comes up with a huge inflation bug, you might be able to claim them back at a later point in time.*
 
 
@@ -129,5 +57,95 @@ MINT_HOST=8333.space
 MINT_PORT=3338
 ```
 
-## Screenshot
-![screenshot](https://user-images.githubusercontent.com/93376500/189533335-68a863e2-bacd-47c1-aecc-e4fb09883d11.jpg)
+# Using Cashu
+
+Cashu should be now installed. To execute the following commands, activate your virtual Poetry environment via
+
+```bash
+poetry shell
+```
+
+If you don't activate your environment, just prepent `poetry run` to all following commands.
+
+## Using the wallet
+
+#### Request a mint
+
+This command will return a Lightning invoice and a payment hash. You have to pay the invoice before you can receive the tokens. Note: Minting tokens involves two steps: requesting a mint, and actually minting tokens (see below).
+
+```bash
+cashu mint 420
+```
+Returns:
+```bash
+Balance: 0 sat (Available: 0 sat in 0 tokens)
+{
+    'pr': 'lnbc4200n1p3jp5clsp5vcfkyqtnkcx9287auhesqwj40che77pd4ymaltc3ruazh3vcgs3qpp5qzwkavpd4pmfkdmq9trdnrk2lswkt0fypqg55h2sucx6yq9ushzsdq4vdshx6r4ypjx2ur0wd5hgxqyjw5qcqpjrzjq0qly7quwdwq2wr52et5gl65dagdgqdwgn9an58mhejnsvmmu996xzetgvqqwzcqqqqqqqqqqqqqqqqq9q9qyysgqfjwnl4za4naf7l2wwcck2gk6y9mvjt5dz9gptfkpl0j50ygkdkuxyjcy3zgd2tk4995yw8gx39cx2qwm9dgwc0t9t6hrgvjzauykqrqpgw0xx3', 
+    'hash': '009d6eb02da8769b37602ac6d98ecafc1d65bd2408114a5d50e60da200bc85c5'
+}
+```
+
+#### Mint tokens
+After paying the invoice, copy the `hash` value from above and add it to the command
+```bash
+cashu mint 420 --hash=009d6eb02da8769b37602ac6d98ecafc1d65bd2408114a5d50e60da200bc85c5
+```
+You should see your balance update accordingly:
+```bash
+Balance: 0 sat (Available: 0 sat in 0 tokens)
+Balance: 420 sat (Available: 420 sat in 4 tokens)
+```
+
+Available tokens here means those tokens that have not been reserved for sending.
+
+#### Check balance
+```bash
+cashu balance
+```
+
+#### Send tokens
+To send tokens to another user, enter
+```bash
+cashu send 69
+```
+You should see the encoded token. Copy the token and send it to another user such as via email or a messenger. The token looks like this:
+```bash
+W3siYW1vdW50IjogMSwgIkMiOiB7IngiOiAzMzg0Mzg0NDYzNzAwMTY1NDA2MTQxMDY3Mzg1MDg5MjA2MTU2NjQxMjM4Nzg5MDE4NzAzODg0NjAwNDUzNTAwNzY3...
+```
+
+You can now see that your available balance has dropped by the amount that you reserved for sending if you enter `cashu balance`:
+```bash
+Balance: 420 sat (Available: 351 sat in 7 tokens)
+```
+
+#### Receive tokens
+To receive tokens, another user enters:
+```bash
+poetry run cashu receive W3siYW1vdW50IjogMSwgIkMiOi...
+```
+You should see the balance increase:
+```bash
+Balance: 0 sat (Available: 0 sat in 0 tokens)
+Balance: 69 sat (Available: 69 sat in 3 tokens)
+```
+
+#### Burn tokens
+The sending user needs to burn (invalidate) their tokens from above, otherwise they will try to double spend them (which won't work because the server keeps a list of all spent tokens):
+```bash
+poetry run cashu burn W3siYW1vdW50IjogMSwgIkMiOi...
+```
+Returns:
+```bash
+Balance: 420 sat (Available: 351 sat in 7 tokens)
+Balance: 351 sat (Available: 351 sat in 7 tokens)
+```
+
+
+## Run a mint yourself
+This command runs the mint on your local computer. Skip this step if you want to use the [public test mint](#test-instance) instead.
+```bash
+mint
+```
+
+You can turn off Lightning support and mint as many tokens as you like by setting `LIGHTNING=FALSE` in the `.env` file.
+

--- a/core/base.py
+++ b/core/base.py
@@ -15,17 +15,43 @@ class Proof(BaseModel):
     amount: int
     C: BasePoint
     secret: str
+    reserved: bool = False  # whether this proof is reserved for sending
 
     @classmethod
     def from_row(cls, row: Row):
-        return dict(
+        return cls(
             amount=row[0],
             C=dict(
                 x=int(row[1]),
                 y=int(row[2]),
             ),
             secret=row[3],
+            reserved=row[4] or False,
         )
+
+    @classmethod
+    def from_dict(cls, d: dict):
+        return cls(
+            amount=d["amount"],
+            C=dict(
+                x=int(d["C"]["x"]),
+                y=int(d["C"]["y"]),
+            ),
+            secret=d["secret"],
+            reserved=d["reserved"] or False,
+        )
+
+    def __getitem__(self, key):
+        return self.__getattribute__(key)
+
+    def __setitem__(self, key, val):
+        self.__setattr__(key, val)
+
+
+class Proofs(BaseModel):
+    """TODO: Use this model"""
+
+    proofs: List[Proof]
 
 
 class Invoice(BaseModel):

--- a/core/migrations.py
+++ b/core/migrations.py
@@ -1,0 +1,51 @@
+from loguru import logger
+from core.db import Database
+from core.db import COCKROACH, POSTGRES, SQLITE
+
+import re
+
+
+async def migrate_databases(db: Database, migrations_module):
+    """Creates the necessary databases if they don't exist already; or migrates them."""
+
+    async def set_migration_version(conn, db_name, version):
+        await conn.execute(
+            """
+            INSERT INTO dbversions (db, version) VALUES (?, ?)
+            ON CONFLICT (db) DO UPDATE SET version = ?
+            """,
+            (db_name, version, version),
+        )
+
+    async def run_migration(db, migrations_module):
+        db_name = migrations_module.__name__.split(".")[-2]
+        for key, migrate in migrations_module.__dict__.items():
+            match = match = matcher.match(key)
+            if match:
+                version = int(match.group(1))
+                if version > current_versions.get(db_name, 0):
+                    await migrate(db)
+
+                    if db.schema == None:
+                        await set_migration_version(db, db_name, version)
+                    else:
+                        async with db.connect() as conn:
+                            await set_migration_version(conn, db_name, version)
+
+    async with db.connect() as conn:
+        if conn.type == SQLITE:
+            exists = await conn.fetchone(
+                "SELECT * FROM sqlite_master WHERE type='table' AND name='dbversions'"
+            )
+        elif conn.type in {POSTGRES, COCKROACH}:
+            exists = await conn.fetchone(
+                "SELECT * FROM information_schema.tables WHERE table_name = 'dbversions'"
+            )
+
+        if not exists:
+            await migrations_module.m000_create_migrations_table(conn)
+
+        rows = await (await conn.execute("SELECT * FROM dbversions")).fetchall()
+        current_versions = {row["db"]: row["version"] for row in rows}
+        matcher = re.compile(r"^m(\d\d\d)_")
+        await run_migration(conn, migrations_module)

--- a/core/settings.py
+++ b/core/settings.py
@@ -4,6 +4,7 @@ env = Env()
 env.read_env()
 
 DEBUG = env.bool("DEBUG", default=False)
+LIGHTNING = env.bool("LIGHTNING", default=False)
 
 MINT_PRIVATE_KEY = env.str("MINT_PRIVATE_KEY")
 

--- a/mint/migrations.py
+++ b/mint/migrations.py
@@ -1,6 +1,15 @@
 from core.db import Database
 
-# from wallet import db
+
+async def m000_create_migrations_table(db):
+    await db.execute(
+        """
+    CREATE TABLE IF NOT EXISTS dbversions (
+        db TEXT PRIMARY KEY,
+        version INT NOT NULL
+    )
+    """
+    )
 
 
 async def m001_initial(db: Database):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,4 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 mint = "mint.app:main"
 cashu = "wallet.cashu:cli"
+wallet-test = "tests.test_wallet:test"

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -118,3 +118,7 @@ async def run_test():
 
 if __name__ == "__main__":
     async_unwrap(run_test())
+
+
+def test():
+    async_unwrap(run_test())

--- a/wallet/crud.py
+++ b/wallet/crud.py
@@ -1,7 +1,5 @@
 import secrets
 from typing import Optional
-
-# from wallet import db
 from core.base import Proof
 from core.db import Connection, Database
 
@@ -19,10 +17,10 @@ async def store_proof(
         VALUES (?, ?, ?, ?)
         """,
         (
-            proof["amount"],
-            str(proof["C"]["x"]),
-            str(proof["C"]["y"]),
-            str(proof["secret"]),
+            proof.amount,
+            str(proof.C.x),
+            str(proof.C.y),
+            str(proof.secret),
         ),
     )
 
@@ -41,7 +39,7 @@ async def get_proofs(
 
 
 async def invalidate_proof(
-    proof: dict,
+    proof: Proof,
     db: Database,
     conn: Optional[Connection] = None,
 ):
@@ -61,9 +59,21 @@ async def invalidate_proof(
         VALUES (?, ?, ?, ?)
         """,
         (
-            proof["amount"],
-            str(proof["C"]["x"]),
-            str(proof["C"]["y"]),
-            str(proof["secret"]),
+            proof.amount,
+            str(proof.C.x),
+            str(proof.C.y),
+            str(proof.secret),
         ),
+    )
+
+
+async def update_proof_reserved(
+    proof: Proof,
+    reserved: bool,
+    db: Database,
+    conn: Optional[Connection] = None,
+):
+    await (conn or db).execute(
+        "UPDATE proofs SET reserved = ? WHERE secret = ?",
+        (reserved, str(proof.secret)),
     )

--- a/wallet/migrations.py
+++ b/wallet/migrations.py
@@ -1,6 +1,15 @@
 from core.db import Database
 
-# from wallet import db
+
+async def m000_create_migrations_table(db):
+    await db.execute(
+        """
+    CREATE TABLE IF NOT EXISTS dbversions (
+        db TEXT PRIMARY KEY,
+        version INT NOT NULL
+    )
+    """
+    )
 
 
 async def m001_initial(db: Database):
@@ -53,3 +62,11 @@ async def m001_initial(db: Database):
         );
     """
     )
+
+
+async def m002_add_proofs_reserved(db):
+    """
+    Column for marking proofs as reserved when they are being sent.
+    """
+
+    await db.execute("ALTER TABLE proofs ADD COLUMN reserved BOOL")


### PR DESCRIPTION
This PR makes the Cashu wallet keep track of the tokens that it reserved for sending so to avoid annoying double spending attempts. 