### PR TITLE
Update README.md - Super Minor Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Cashu should be now installed. To execute the following commands, activate your 
 poetry shell
 ```
 
-If you don't activate your environment, just prepent `poetry run` to all following commands.
+If you don't activate your environment, just prepend `poetry run` to all following commands.
 ## Configuration
 ```bash
 mv .env.example .env


### PR DESCRIPTION
I believe author intends to use "prepend" not "prepent" on Line 63. Small change, big meaning.